### PR TITLE
Make compressed man pages reproducible

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -86,7 +86,7 @@ class Installer
 
       gzip = `which gzip`
       gzip.chomp!
-      `#{gzip} -f #{omf}`
+      `#{gzip} -fn #{omf}`
     end
   end
 

--- a/install.rb
+++ b/install.rb
@@ -86,7 +86,7 @@ class Installer
 
       gzip = `which gzip`
       gzip.chomp!
-      `#{gzip} -fn #{omf}`
+      `#{gzip} --force --no-name #{omf}`
     end
   end
 


### PR DESCRIPTION
gzip(1) stores a timestamp in headers unless told not to do so: https://wiki.debian.org/ReproducibleBuilds/TimestampsInGzipHeaders