### PR TITLE
Reenable acceptance tests for MacOS

### DIFF
--- a/.github/actions/presuite.rb
+++ b/.github/actions/presuite.rb
@@ -130,7 +130,10 @@ end
 
 def verify_facter_standalone_exits_0
   Dir.chdir(ENV['FACTER_ROOT']) do
-    run('bundle install --without development')
+    # `documentation` group contains ronn and hpricot
+    # both gems are ancient, dead upstream, don't compile on modern rubies
+    # and are only required for building manpages
+    run('bundle install --without development:documentation')
     run('bundle exec facter')
   end
 end

--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -62,8 +62,8 @@ jobs:
           primary_interface=`route -n get default | awk '/interface: */{print $NF}'`
           sudo ifconfig $primary_interface inet6 add ::1/64
 
-      - name: Run acceptance tests on Linux-like platform
-        if: runner.os == 'Linux'
+      - name: Run acceptance tests on Linux and MacOS platform
+        if: runner.os != 'Windows'
         run: sudo -E "PATH=$PATH" ruby $FACTER_ROOT/.github/actions/presuite.rb ${{ matrix.os }}
 
       - name: Run acceptance tests on Windows-like platform


### PR DESCRIPTION
In https://github.com/OpenVoxProject/facter/commit/62d38374f9ae3c47c2649fa147d4cb8de609aa5c we accidentally disabled
acceptance tests on MacOS runners.