### PR TITLE
Fix rubocop offense

### DIFF
--- a/lib/facter/custom_facts/core/suitable.rb
+++ b/lib/facter/custom_facts/core/suitable.rb
@@ -18,7 +18,7 @@ module LegacyFacter
       # @return [void]
       #
       # @api public
-      def has_weight(weight) # rubocop:disable Naming/PredicateName
+      def has_weight(weight) # rubocop:disable Naming/PredicatePrefix
         @weight = weight
         self
       end


### PR DESCRIPTION
```
lib/facter/custom_facts/core/suitable.rb:21:30: W: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of Naming/PredicateName (did you mean Naming/PredicatePrefix?).
      def has_weight(weight) # rubocop:disable Naming/PredicateName
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
